### PR TITLE
br2-clerk: use topics to group commands

### DIFF
--- a/src/bin/br2-clerk.rs
+++ b/src/bin/br2-clerk.rs
@@ -6,31 +6,19 @@
 // SPDX-License-Identifier: MIT
 //
 
-use std::path::PathBuf;
-
 use anyhow::{Context, Result};
 use br2_utils::BuildrootExplorer;
-use clap::{Args, Parser, Subcommand};
-
-#[derive(Debug, Args)]
-struct ListArgs {
-    object: commands::Object,
-}
-
-#[derive(Debug, Args)]
-struct BumpArgs {
-    #[arg(help = "Name of the package to bump")]
-    name: String,
-    #[arg(help = "New version of the package")]
-    version: String,
-}
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+use topics::defconfig::Defconfig;
+use topics::package::Package;
 
 #[derive(Debug, Subcommand)]
-enum Command {
-    #[command(visible_alias = "ls")]
-    List(ListArgs),
-    #[command(visible_alias = "b")]
-    Bump(BumpArgs),
+enum Topic {
+    #[clap(visible_aliases = ["d", "def"])]
+    Defconfig(Defconfig),
+    #[clap(visible_aliases = ["p", "pkg"])]
+    Package(Package),
 }
 
 #[derive(Debug, Parser)]
@@ -44,8 +32,8 @@ struct Cli {
     main: Option<PathBuf>,
     #[arg(short, long, help = "Path to external tree")]
     externals: Vec<PathBuf>,
-    #[command(subcommand)]
-    command: Command,
+    #[command(subcommand, help = "Topic to handle")]
+    topic: Topic,
 }
 pub fn main() -> Result<()> {
     let args = Cli::parse();
@@ -58,46 +46,110 @@ pub fn main() -> Result<()> {
     let buildroot = explorer
         .explore()
         .with_context(|| "Failed to explore environment")?;
-    match args.command {
-        Command::List(args) => commands::list(&buildroot, args.object)?,
-        Command::Bump(args) => commands::bump(&buildroot, &args.name, &args.version)?,
+    match args.topic {
+        Topic::Defconfig(ref topic) => topic.execute(&buildroot)?,
+        Topic::Package(ref topic) => topic.execute(&buildroot)?,
     }
     Ok(())
 }
 
-mod commands {
-    use br2_utils::{Buildroot, Error};
-    use clap::ValueEnum;
-    use std::collections::BTreeSet;
+mod topics {
+    pub mod defconfig {
+        use br2_utils::{Buildroot, Error};
+        use clap::{Args, Subcommand};
+        use std::collections::BTreeSet;
 
-    #[derive(Debug, Clone, ValueEnum)]
-    pub enum Object {
-        Defconfigs,
-        Packages,
-    }
+        #[derive(Debug, Subcommand)]
+        enum DefconfigCommand {
+            #[clap(visible_alias = "ls")]
+            List,
+        }
 
-    impl std::fmt::Display for Object {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            self.to_possible_value()
-                .expect("Skipped value")
-                .get_name()
-                .fmt(f)
+        #[derive(Debug, Args)]
+        pub struct Defconfig {
+            #[command(subcommand)]
+            command: DefconfigCommand,
+        }
+
+        impl Defconfig {
+            pub fn execute(&self, buildroot: &Buildroot) -> Result<(), Error> {
+                match self.command {
+                    DefconfigCommand::List => {
+                        let items: BTreeSet<&String> =
+                            buildroot.defconfigs().map(|(n, _)| n).collect();
+                        for item in items {
+                            println!("{item}");
+                        }
+                        Ok(())
+                    }
+                }
+            }
         }
     }
 
-    pub fn list(buildroot: &Buildroot, object: Object) -> Result<(), Error> {
-        let items: BTreeSet<&String> = match object {
-            Object::Defconfigs => buildroot.defconfigs().map(|(n, _)| n).collect(),
-            Object::Packages => buildroot.packages().map(|(n, _)| n).collect(),
-        };
-        for item in items {
-            println!("{item}");
-        }
-        Ok(())
-    }
+    pub mod package {
+        use br2_utils::{Buildroot, Error};
+        use clap::{Args, Subcommand};
+        use std::collections::{BTreeMap, BTreeSet};
 
-    /// Change the version of package named `name` to `version`.
-    pub fn bump(buildroot: &Buildroot, name: &str, version: &str) -> Result<(), Error> {
-        buildroot.set_package_version(name, version)
+        #[derive(Debug, Args)]
+        struct ListArgs {
+            #[arg(short, long, help = "Show details")]
+            details: bool,
+        }
+
+        #[derive(Debug, Args)]
+        struct BumpArgs {
+            #[arg(required(true), help = "Name of the package to bump")]
+            name: String,
+            #[arg(required(true), help = "New version of the package")]
+            version: String,
+        }
+
+        #[derive(Debug, Subcommand)]
+        enum PackageCommand {
+            #[clap(visible_alias = "ls")]
+            List(ListArgs),
+            #[clap(visible_alias = "b")]
+            Bump(BumpArgs),
+        }
+
+        #[derive(Debug, Args)]
+        pub struct Package {
+            #[command(subcommand)]
+            command: PackageCommand,
+        }
+
+        impl Package {
+            pub fn execute(&self, buildroot: &Buildroot) -> Result<(), Error> {
+                match self.command {
+                    PackageCommand::List(ref args) => {
+                        let pkg_names = buildroot.packages().map(|(n, _)| n);
+                        if args.details {
+                            let items: BTreeMap<&String, String> = pkg_names
+                                .map(|n| {
+                                    let v = buildroot
+                                        .get_package_version(n)
+                                        .unwrap_or("unknown".to_string());
+                                    (n, v)
+                                })
+                                .collect();
+                            for (n, v) in items {
+                                println!("{n:<32} {v}");
+                            }
+                        } else {
+                            let items: BTreeSet<&String> = pkg_names.collect();
+                            for item in items {
+                                println!("{item}");
+                            }
+                        }
+                        Ok(())
+                    }
+                    PackageCommand::Bump(ref args) => {
+                        buildroot.set_package_version(&args.name, &args.version)
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Instead of using verbs as commands, group verbs into topics and use them as commands: one group of commands for defconfigs, another for packages.