### PR TITLE
defconfig: allow '.' char in symbol name pattern

### DIFF
--- a/src/bin/br2-clerk.rs
+++ b/src/bin/br2-clerk.rs
@@ -57,7 +57,15 @@ mod topics {
     pub mod defconfig {
         use br2_utils::{Buildroot, Error};
         use clap::{Args, Subcommand};
-        use std::collections::BTreeSet;
+        use std::{collections::BTreeSet, path::PathBuf};
+
+        #[derive(Debug, Args)]
+        struct BuildArgs {
+            #[arg(help = "Name of the defconfig")]
+            name: String,
+            #[arg(help = "Path to output directory")]
+            output: PathBuf,
+        }
 
         #[derive(Debug, Args)]
         struct GetArgs {
@@ -69,6 +77,9 @@ mod topics {
 
         #[derive(Debug, Subcommand)]
         enum DefconfigCommand {
+            /// Build an embedded system using a defconfig
+            #[clap(visible_alias = "b")]
+            Build(BuildArgs),
             /// Get value of a symbol
             #[clap(visible_alias = "g")]
             Get(GetArgs),
@@ -86,6 +97,11 @@ mod topics {
         impl Defconfig {
             pub fn execute(&self, buildroot: &Buildroot) -> Result<(), Error> {
                 match self.command {
+                    DefconfigCommand::Build(ref args) => {
+                        let _status = buildroot.build_defconfig(&args.name, &args.output)?;
+                        // FIXME: handle status
+                        Ok(())
+                    }
                     DefconfigCommand::Get(ref args) => {
                         let defconfig = buildroot.get_defconfig(&args.name)?;
                         let symbol = defconfig

--- a/src/buildroot.rs
+++ b/src/buildroot.rs
@@ -242,6 +242,27 @@ impl Buildroot {
             .ok_or(Error::UnknownDefconfig(name.to_string()))
             .and_then(|(_, p)| Ok(defconfig::Defconfig::from_path(p)?))
     }
+
+    /// Build an embedded system using a defconfig
+    pub fn build_defconfig<P: AsRef<Path>>(&self, name: &str, output: P) -> Result<bool, Error> {
+        let input = self.main_tree_path();
+        let status = std::process::Command::new("make")
+            .arg(format!("O={}", output.as_ref().display()))
+            .arg("-C")
+            .arg(input.as_os_str())
+            .arg(name)
+            .status()?;
+        Ok(status.success())
+    }
+
+    /// Return the path to the main tree
+    fn main_tree_path(&self) -> &Path {
+        if let BuildrootTree::Main(m) = &self.trees[0] {
+            m.path.as_path()
+        } else {
+            unreachable!()
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/defconfig.rs
+++ b/src/defconfig.rs
@@ -81,9 +81,9 @@ impl FromStr for Symbol {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         lazy_static! {
-            static ref SYMBOL_SET: Regex = Regex::new(r"(BR2_[a-zA-Z0-9_]+)=(.+)").unwrap();
+            static ref SYMBOL_SET: Regex = Regex::new(r"(BR2_[a-zA-Z0-9_.]+)=(.+)").unwrap();
             static ref SYMBOL_NOTSET: Regex =
-                Regex::new(r"# (BR2_[a-zA-Z0-9_]+) is not set").unwrap();
+                Regex::new(r"# (BR2_[a-zA-Z0-9_.]+) is not set").unwrap();
         }
 
         if let Some(caps) = SYMBOL_SET.captures(s) {


### PR DESCRIPTION
If any symbol in the defconfig has a '.' in it, it fails to parse.