### PR TITLE
Rework the way to perform a build

### DIFF
--- a/src/bin/br2-clerk.rs
+++ b/src/bin/br2-clerk.rs
@@ -55,19 +55,9 @@ pub fn main() -> Result<()> {
 
 mod topics {
     pub mod defconfig {
-        use br2_utils::{BuildMode, Buildroot, Error};
+        use br2_utils::{Buildroot, Error};
         use clap::{Args, Subcommand};
-        use std::{collections::BTreeSet, path::PathBuf};
-
-        #[derive(Debug, Args)]
-        struct BuildArgs {
-            #[arg(short, long, help = "Build mode", default_value_t = BuildMode::Full)]
-            mode: BuildMode,
-            #[arg(help = "Name of the defconfig")]
-            name: String,
-            #[arg(help = "Path to output directory")]
-            output: PathBuf,
-        }
+        use std::collections::BTreeSet;
 
         #[derive(Debug, Args)]
         struct GetArgs {
@@ -79,9 +69,6 @@ mod topics {
 
         #[derive(Debug, Subcommand)]
         enum DefconfigCommand {
-            /// Build an embedded system using a defconfig
-            #[clap(visible_alias = "b")]
-            Build(BuildArgs),
             /// Get value of a symbol
             #[clap(visible_alias = "g")]
             Get(GetArgs),
@@ -99,9 +86,6 @@ mod topics {
         impl Defconfig {
             pub fn execute(&self, buildroot: &Buildroot) -> Result<(), Error> {
                 match self.command {
-                    DefconfigCommand::Build(ref args) => {
-                        buildroot.build_defconfig(&args.name, &args.output, args.mode)
-                    }
                     DefconfigCommand::Get(ref args) => {
                         let defconfig = buildroot.get_defconfig(&args.name)?;
                         let symbol = defconfig

--- a/src/bin/br2-clerk.rs
+++ b/src/bin/br2-clerk.rs
@@ -10,11 +10,14 @@ use anyhow::{Context, Result};
 use br2_utils::BuildrootExplorer;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
+use topics::build::Build;
 use topics::defconfig::Defconfig;
 use topics::package::Package;
 
 #[derive(Debug, Subcommand)]
 enum Topic {
+    #[clap(visible_aliases = ["b", "bld"])]
+    Build(Build),
     #[clap(visible_aliases = ["d", "def"])]
     Defconfig(Defconfig),
     #[clap(visible_aliases = ["p", "pkg"])]
@@ -47,6 +50,7 @@ pub fn main() -> Result<()> {
         .explore()
         .with_context(|| "Failed to explore environment")?;
     match args.topic {
+        Topic::Build(ref topic) => topic.execute(&buildroot)?,
         Topic::Defconfig(ref topic) => topic.execute(&buildroot)?,
         Topic::Package(ref topic) => topic.execute(&buildroot)?,
     }
@@ -54,6 +58,44 @@ pub fn main() -> Result<()> {
 }
 
 mod topics {
+    pub mod build {
+        use br2_utils::{builder::BuildStep, Buildroot, Error};
+        use clap::{Args, Subcommand};
+        use std::path::PathBuf;
+
+        #[derive(Debug, Args)]
+        struct RunArgs {
+            #[arg(short, long, help = "Build step", default_value_t = BuildStep::All)]
+            step: BuildStep,
+            #[arg(help = "Name of the defconfig")]
+            name: String,
+            #[arg(help = "Path to output directory")]
+            output: PathBuf,
+        }
+
+        #[derive(Debug, Subcommand)]
+        enum BuildCommand {
+            /// Build an embedded system using a defconfig
+            #[clap(visible_alias = "r")]
+            Run(RunArgs),
+        }
+
+        #[derive(Debug, Args)]
+        pub struct Build {
+            #[command(subcommand)]
+            command: BuildCommand,
+        }
+
+        impl Build {
+            pub fn execute(&self, buildroot: &Buildroot) -> Result<(), Error> {
+                match self.command {
+                    BuildCommand::Run(ref args) => {
+                        buildroot.build(&args.name, &args.output, args.step)
+                    }
+                }
+            }
+        }
+    }
     pub mod defconfig {
         use br2_utils::{Buildroot, Error};
         use clap::{Args, Subcommand};

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,106 @@
+//
+// This file is part of br2-utils
+//
+// SPDX-FileCopyrightText: © 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! Provide helpers for building using a defconfig.
+
+use std::{path::PathBuf, str::FromStr};
+
+use thiserror::Error;
+
+/// Errors reported when performing a build
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Build failed")]
+    BuildFailed,
+    #[error("Invalid step")]
+    InvalidStep,
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Represent a Buildroot builder
+#[derive(Debug)]
+pub struct Builder {
+    pub(crate) defconfig: PathBuf,
+    pub(crate) output: PathBuf,
+    pub(crate) main: PathBuf,
+    pub(crate) externals: Vec<PathBuf>,
+}
+
+/// Represent a build step
+#[derive(Debug, Clone, Copy)]
+pub enum BuildStep {
+    /// Initialize and build
+    All,
+    /// Initialize a build using defconfig
+    Init,
+    /// Continue a previously initialized build
+    Main,
+}
+
+impl FromStr for BuildStep {
+    type Err = self::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(BuildStep::All),
+            "init" => Ok(BuildStep::Init),
+            "main" => Ok(BuildStep::Main),
+            _ => Err(Error::InvalidStep),
+        }
+    }
+}
+
+impl std::fmt::Display for BuildStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BuildStep::All => write!(f, "all"),
+            BuildStep::Init => write!(f, "init"),
+            BuildStep::Main => write!(f, "main"),
+        }
+    }
+}
+
+impl Builder {
+    /// Run a build step
+    pub fn run_step(&self, step: BuildStep) -> Result<(), Error> {
+        let mut targets = vec![];
+        match step {
+            BuildStep::Init => targets.push("defconfig"),
+            BuildStep::All => targets.extend_from_slice(&["defconfig", "all"]),
+            BuildStep::Main => targets.push("all"),
+        }
+        // "defconfig" can not be batched with "all", so build each separately.
+        for target in targets {
+            self.build_targets(&[target])?;
+        }
+        Ok(())
+    }
+
+    /// Build a list of targets specified by name
+    pub fn build_targets(&self, targets: &[&str]) -> Result<(), Error> {
+        let mut cmd = std::process::Command::new("make");
+        let external: String = self.externals.iter().fold(String::new(), |a, p| {
+            a + ":" + &p.as_os_str().to_string_lossy()
+        });
+        if !external[1..].is_empty() {
+            cmd.arg(format!("BR2_EXTERNAL={}", &external[1..]));
+        }
+        let defconfig = format!("BR2_DEFCONFIG={}", self.defconfig.to_string_lossy());
+        let output = format!("O={}", self.output.to_string_lossy());
+        cmd.arg("-C")
+            .arg(self.main.as_os_str())
+            .arg(output)
+            .arg(defconfig);
+        for target in targets {
+            cmd.arg(target);
+        }
+        let status = cmd.status()?;
+        status.success().then_some(()).ok_or(Error::BuildFailed)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 //! Provide helpers to handle a [Buildroot](https://buildroot.org) environment.
 
+pub mod builder;
 mod buildroot;
 pub mod defconfig;
 pub mod package;


### PR DESCRIPTION
This pull request reworks the way to build an embedded firmware using a defconfig by:

- removing "build" command for "defconfig" topic.
- adding helpers to "Buildroot" to create a "Builder" to build using a
  defconfig.
- adding "build" topic to "br2-clerk"