### PR TITLE
Add tool and helper to manage builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "lazy_static",
  "regex",
  "serde",
@@ -89,6 +90,12 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -148,6 +155,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +200,17 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "getrandom"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -308,6 +346,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -490,6 +548,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,8 +77,10 @@ dependencies = [
  "clap",
  "lazy_static",
  "regex",
+ "serde",
  "tempdir",
  "thiserror",
+ "toml",
  "walkdir",
 ]
 
@@ -167,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +191,16 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -336,6 +360,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +433,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -500,3 +587,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ tempdir = "0.3.7"
 walkdir = "2.3.3"
 clap = { version = "4.2.1", features = ["derive"] }
 anyhow = "1.0.70"
+serde = { version = "1.0.159", features = ["derive"] }
+toml = "0.7.3"
 
 [[bin]]
 name = "br2-clerk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,12 @@ tempdir = "0.3.7"
 walkdir = "2.3.3"
 clap = { version = "4.2.1", features = ["derive"] }
 anyhow = "1.0.70"
-serde = { version = "1.0.159", features = ["derive"] }
+dirs = "5.0.0"
 toml = "0.7.3"
+serde = { version = "1.0.159", features = ["derive"] }
 
 [[bin]]
 name = "br2-clerk"
+
+[[bin]]
+name = "br2-mason"

--- a/src/bin/br2-mason.rs
+++ b/src/bin/br2-mason.rs
@@ -1,0 +1,211 @@
+//
+// This file is part of br2-utils
+//
+// SPDX-FileCopyrightText: © 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use anyhow::{anyhow, Context, Result};
+use br2_utils::mason::Mason;
+use clap::{Parser, Subcommand};
+use commands::{add::Add, build::Build, delete::Delete, execute::Execute, list::List, show::Show};
+use std::path::PathBuf;
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    #[clap(visible_alias = "a")]
+    Add(Add),
+    #[clap(visible_alias = "b")]
+    Build(Build),
+    #[clap(visible_alias = "d")]
+    Delete(Delete),
+    #[clap(visible_alias = "e")]
+    Execute(Execute),
+    #[clap(visible_aliases = ["l", "ls"])]
+    List(List),
+    #[clap(visible_aliases = ["s", "sh"])]
+    Show(Show),
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "br2-mason", version, about = "Manage Buildroot builds")]
+struct Cli {
+    #[arg(short, long, help = " Path to build definitions")]
+    storage: Option<PathBuf>,
+    #[command(subcommand, help = "Build command")]
+    command: Command,
+}
+
+pub fn main() -> Result<()> {
+    let args = Cli::parse();
+    let storage = args
+        .storage
+        .or_else(utils::user_local_storage)
+        .ok_or(anyhow!("No storage found"))?;
+    let mason = Mason::new(storage);
+    match args.command {
+        Command::Add(ref cmd) => cmd
+            .execute(&mason)
+            .with_context(|| "Failed to add build definition")?,
+        Command::Build(ref cmd) => cmd
+            .execute(&mason)
+            .with_context(|| "Failed to build using build definition")?,
+        Command::Delete(ref cmd) => cmd
+            .execute(&mason)
+            .with_context(|| "Failed to delete build definition")?,
+        Command::Execute(ref cmd) => cmd
+            .execute(&mason)
+            .with_context(|| "Failed to execute target(s)")?,
+        Command::List(ref cmd) => cmd
+            .execute(&mason)
+            .with_context(|| "Failed to list build definitions")?,
+        Command::Show(ref cmd) => cmd
+            .execute(&mason)
+            .with_context(|| "Failed to show build definition")?,
+    }
+    Ok(())
+}
+
+mod commands {
+    pub mod add {
+        use std::path::PathBuf;
+
+        use anyhow::{Context, Error};
+        use br2_utils::{mason::Mason, BuildrootExplorer};
+        use clap::Args;
+
+        #[derive(Debug, Args)]
+        pub struct Add {
+            #[arg(short, long, help = "Path to main tree")]
+            main: Option<PathBuf>,
+            #[arg(
+                short,
+                long = "external",
+                help = "Path to external tree",
+                value_name = "EXTERNAL"
+            )]
+            externals: Vec<PathBuf>,
+            #[arg(help = "Name of the build")]
+            name: String,
+            #[arg(help = "Name of the defconfig")]
+            defconfig: String,
+            #[arg(help = "Path to output directory")]
+            output: PathBuf,
+        }
+
+        impl Add {
+            pub fn execute(&self, mason: &Mason) -> Result<(), Error> {
+                let cur_dir = std::env::current_dir()?;
+                let main = self.main.as_ref().unwrap_or(&cur_dir);
+                let mut explorer = BuildrootExplorer::new(main);
+                for external in &self.externals {
+                    explorer.external_tree(external);
+                }
+                let buildroot = explorer
+                    .explore()
+                    .with_context(|| "Failed to explore Buildroot tree")?;
+                let builder = buildroot
+                    .create_builder(&self.defconfig, &self.output)
+                    .with_context(|| "Failed to create Buildroot builder")?;
+                mason.add_from_builder(&self.name, &builder)?;
+                Ok(())
+            }
+        }
+    }
+    pub mod build {
+        use br2_utils::{
+            builder::BuildStep,
+            mason::{Error, Mason},
+        };
+        use clap::Args;
+
+        #[derive(Debug, Args)]
+        pub struct Build {
+            #[arg(short, long, help = "Build step", default_value_t = BuildStep::All)]
+            step: BuildStep,
+            #[arg(help = "Name of the build")]
+            name: String,
+        }
+
+        impl Build {
+            pub fn execute(&self, mason: &Mason) -> Result<(), Error> {
+                mason.build(&self.name, self.step)
+            }
+        }
+    }
+    pub mod delete {
+        use br2_utils::mason::{Error, Mason};
+        use clap::Args;
+
+        #[derive(Debug, Args)]
+        pub struct Delete {
+            #[arg(help = "Name of the build")]
+            name: String,
+        }
+
+        impl Delete {
+            pub fn execute(&self, mason: &Mason) -> Result<(), Error> {
+                mason.delete(&self.name)
+            }
+        }
+    }
+    pub mod execute {
+        use br2_utils::mason::{Error, Mason};
+        use clap::Args;
+
+        #[derive(Debug, Args)]
+        pub struct Execute {
+            #[arg(help = "Name of the build")]
+            name: String,
+            #[arg(help = "Name of the target to build", value_name = "TARGET")]
+            targets: Vec<String>,
+        }
+
+        impl Execute {
+            pub fn execute(&self, mason: &Mason) -> Result<(), Error> {
+                mason.execute(&self.name, &self.targets)
+            }
+        }
+    }
+    pub mod list {
+        use br2_utils::mason::{Error, Mason};
+        use clap::Args;
+
+        #[derive(Debug, Args)]
+        pub struct List;
+
+        impl List {
+            pub fn execute(&self, mason: &Mason) -> Result<(), Error> {
+                for entry in mason.list()? {
+                    println!("{entry}");
+                }
+                Ok(())
+            }
+        }
+    }
+    pub mod show {
+        use br2_utils::mason::{Error, Mason};
+        use clap::Args;
+
+        #[derive(Debug, Args)]
+        pub struct Show {
+            #[arg(help = "Name of the build")]
+            name: String,
+        }
+
+        impl Show {
+            pub fn execute(&self, mason: &Mason) -> Result<(), Error> {
+                mason.show(&self.name)
+            }
+        }
+    }
+}
+
+mod utils {
+    use std::path::PathBuf;
+
+    pub fn user_local_storage() -> Option<PathBuf> {
+        dirs::config_local_dir().map(|p| p.join("br2-utils"))
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -83,7 +83,7 @@ impl Builder {
     }
 
     /// Build a list of targets specified by name
-    pub fn build_targets(&self, targets: &[&str]) -> Result<(), Error> {
+    pub fn build_targets<S: AsRef<str>>(&self, targets: &[S]) -> Result<(), Error> {
         let mut cmd = std::process::Command::new("make");
         let external: String = self.externals.iter().fold(String::new(), |a, p| {
             a + ":" + &p.as_os_str().to_string_lossy()
@@ -98,7 +98,7 @@ impl Builder {
             .arg(output)
             .arg(defconfig);
         for target in targets {
-            cmd.arg(target);
+            cmd.arg(target.as_ref());
         }
         let status = cmd.status()?;
         status.success().then_some(()).ok_or(Error::BuildFailed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod builder;
 mod buildroot;
 pub mod defconfig;
+pub mod mason;
 pub mod package;
 
 pub use buildroot::*;

--- a/src/mason.rs
+++ b/src/mason.rs
@@ -1,0 +1,116 @@
+//
+// This file is part of br2-utils
+//
+// SPDX-FileCopyrightText: © 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! Provide helpers for managing builds.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use thiserror::Error;
+
+use super::builder::{self, BuildStep, Builder};
+
+/// Errors reported when managing builds.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Builder error: {0}")]
+    Builder(#[from] builder::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Manages builds.
+#[derive(Debug)]
+pub struct Mason {
+    storage: PathBuf,
+}
+
+impl Mason {
+    /// Create a new mason, using `storage` as location for build definitions.
+    pub fn new<P: AsRef<Path>>(storage: P) -> Self {
+        Self {
+            storage: storage.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Add a new build definition, created from a `Builder`
+    pub fn add_from_builder(&self, name: &str, builder: &Builder) -> Result<(), Error> {
+        if !self.storage.exists() {
+            fs::create_dir_all(&self.storage)?;
+        }
+        let path = self.build_definition_path(name);
+        let text = builder.to_toml()?;
+        fs::write(path, text)?;
+        Ok(())
+    }
+
+    /// List all available build definitions.
+    pub fn list(&self) -> Result<Vec<String>, Error> {
+        let dir = fs::read_dir(&self.storage)?;
+        let names = dir
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter_map(|p| {
+                if p.extension().map_or(false, |e| e == "toml") {
+                    Some(p)
+                } else {
+                    None
+                }
+            })
+            .filter_map(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()))
+            .collect::<Vec<String>>();
+        Ok(names)
+    }
+
+    /// delete a build definition.
+    pub fn delete(&self, name: &str) -> Result<(), Error> {
+        let path = self.build_definition_path(name);
+        fs::remove_file(path)?;
+        Ok(())
+    }
+
+    /// Perform a build from a definition.
+    pub fn build(&self, name: &str, step: BuildStep) -> Result<(), Error> {
+        let builder = self.create_builder(name)?;
+        builder.run_step(step)?;
+        Ok(())
+    }
+
+    /// Build some specific targets of a build definition.
+    pub fn execute<S: AsRef<str>>(&self, name: &str, targets: &[S]) -> Result<(), Error> {
+        let builder = self.create_builder(name)?;
+        builder.build_targets(targets)?;
+        Ok(())
+    }
+
+    ///  Print contents of a build definition
+    pub fn show(&self, name: &str) -> Result<(), Error> {
+        let s = self.read_build_definition(name)?;
+        println!("{s}");
+        Ok(())
+    }
+
+    fn read_build_definition(&self, name: &str) -> Result<String, Error> {
+        let path = self.build_definition_path(name);
+        let s = fs::read_to_string(path)?;
+        Ok(s)
+    }
+
+    fn create_builder(&self, name: &str) -> Result<Builder, Error> {
+        let s = self.read_build_definition(name)?;
+        let b = Builder::from_toml(&s)?;
+        Ok(b)
+    }
+
+    fn build_definition_path(&self, name: &str) -> PathBuf {
+        let mut path = self.storage.join(name);
+        path.set_extension("toml");
+        path
+    }
+}


### PR DESCRIPTION
This pull request adds a new module which provides `Mason`, a helper to manage
builds:

- information about a build (trees, defconfig, output) is stored in a TOML file,
  known as a "build definition".
- a build can be started by using its build definition handle.
- build definitions can be listed, printed and removed.

A tool named `br2-mason` is provided to showcase features.

Usage examples:

```sh
# Add a build definition named "foo"
cd buildroot
br2-mason add foo qemu_x86_64_defconfig /tmp/test
# List known build definitions
br2-mason ls
# Run build with handle "foo"
br2-mason run foo
```